### PR TITLE
Update namespace to avoid problems

### DIFF
--- a/scripts/migration-tracker.coffee
+++ b/scripts/migration-tracker.coffee
@@ -82,7 +82,7 @@ class MigrationTracker
     
     template = "```using FluentMigrator;\n"
     template += "\n"
-    template += "namespace Autobahn.DataMigrations.Migrations\n"
+    template += "namespace Autobahn.DataMigrations.DB_01_Migrations\n"
     template += "{\n"
     template += "    [Migration(#{yyyy}#{mm}#{dd}#{migrationNumber})]\n"
     template += "    public class Migration_#{yyyy}#{mm}#{dd}#{migrationNumber}_NewMigration : ForwardOnlyMigration\n"


### PR DESCRIPTION
Using the old namespace causes problems (the migrations aren't run anymore if they're in the old namespace)